### PR TITLE
Remove leading whitespace from config.php

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,4 +1,3 @@
-
 <?php
   //PMPD Config
   $pmpConfigVersion = '2';


### PR DESCRIPTION
This would cause an error on systems that don't swallow warnings about sessions already being started,

(It took me a while to work out why the out of the box config didn't work!)