### PR TITLE
[Security] Prevent Exposure of Plex Token to Unauthenticated Users

### DIFF
--- a/getData.php
+++ b/getData.php
@@ -2,6 +2,11 @@
 //For feedback, suggestions, or issues please visit https://www.mattsshack.com/plex-movie-poster-display/
 include 'config.php';
 include 'status.php';
+
+// Security Work Around (quick fix)
+include 'getPoster.php';
+
+
 $results = Array();
 $movies = Array();
 ob_start();
@@ -175,7 +180,7 @@ if ($customImageEnabled != "Enabled") {
         }
         $display = "url('cache/posters/$poster')";
     } else {
-        $display = "url('http://$plexServer:32400$art?X-Plex-Token=$plexToken')";
+        $display = "url('data:image/jpeg;base64,".getPoster($art)."')";
     }
     // Figure out which text goes where
     switch($topSelection) {

--- a/getPoster.php
+++ b/getPoster.php
@@ -1,0 +1,37 @@
+<?php
+include 'config.php';
+
+// Hot Fix. Security!
+// This will grab the image server side.
+
+function getPoster($artWorkLocation) {
+	global $plexServer, $plexToken;
+
+	$posterUrl = "http://$plexServer:32400$artWorkLocation?X-Plex-Token=$plexToken";
+
+	// Grab Poster
+	$ch = curl_init($posterUrl);
+	curl_setopt_array(
+		$ch,
+		 array(
+			CURLOPT_RETURNTRANSFER  => true
+		)
+	);
+	$imgRaw = curl_exec($ch);
+	curl_close($ch);
+
+	// Get information about the image.
+	$imgInfo=getImageSizeFromString($imgRaw);
+
+	// Ensure image, is indeed an image.
+	if (empty($imgInfo['mime']) || strpos($imgInfo['mime'], 'image/') !== 0) {
+		die('Invalid Image');
+	}
+
+	// Create base64 version of image
+	$imgBase64 = base64_encode($imgRaw);
+
+	// Return Base64
+	return $imgBase64;
+}
+?>

--- a/index.php
+++ b/index.php
@@ -47,8 +47,6 @@ $pmpImageSpeed = ($pmpImageSpeed * 1000);
                         $('#' + key).html(val);
                     }
                 });
-                fitty('.userText', {maxSize: 100, minSize: 10});
-                fitty.fitAll();
             });
 
             $(document).keypress(function(event){
@@ -78,8 +76,6 @@ $pmpImageSpeed = ($pmpImageSpeed * 1000);
                         }
                     });
                 });
-                fitty('.userText', {maxSize: 100, minSize: 10});
-                fitty.fitAll();
             }, <?php echo $pmpImageSpeed; ?>);
         });
 


### PR DESCRIPTION
This is a quick fix I have put together to mitigate a "vulnerability" in the code, currently the "Plex-Token" is exposed to any user viewing the page, this is dangerous as this code can be used to perform any actions as an authenticated user.

I have mitigated this issue by creating a quick function `getPoster` which retrieves the image server side, encodes it in Base64 before passing this to the client - this means, the end user does not need to have any direct access with the plex server nor do they get given a token.

There is also another, unrelated change  (_modifications on lines 50, 51, 81, 82 of index.php_) - which I can remove if you'd prefer, I did intend to make another commit with more complete changes to the code, however I thought the above issue was pressing enough to warrant creating a merge request now. 

The change I made on lines _50, 51, 81, 82_ of index.php were to remove the use `fitty` text scaling, which to me (maybe i'm misunderstanding) does not make much sense - since we already statically set font sizes, my experience at least was that on initial load font would be "scaled" in size, to then change making an unpleasant looking transition. 