### PR TITLE
Feature/tv season

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,6 +1,6 @@
-next-version: 2.8.1
-mode: ContinuousDelivery
 branches: {}
 ignore:
   sha: []
 merge-message-formats: {}
+mode: ContinuousDelivery
+next-version: 2.9.0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ If you would like to create a docker image locally the instructions can be found
 ## Font Support
 If you would like to use custom fonts for your posters, there is now options for that and extra instructions can be found [here](docs/FontConfig.md).
 
-## [Change Logs](documentation/ChangeLogs.md)
+## [Change Logs](docs/ChangeLogs.md)
 
 **v2.x To Do**\
 Font Outline Size and Color for the Bottom Text.\

--- a/assets/plexmovieposter/PlexLib.php
+++ b/assets/plexmovieposter/PlexLib.php
@@ -1,0 +1,236 @@
+<?php
+
+//  NEED TO SUPPORT "movie" and "show" as well as "clients"
+
+function plex_metadata_title($mediaType = "episode") {
+    global $mediaTitle, $mediaTitle_MetadataID, $clients;
+
+    // Title
+    switch ($mediaType) {
+        case "episode":
+            $mediaTitle = $clients['title']; // Episode Title
+            pmp_Logging("getTVShowData", "mediaTitle @ Episode (title) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            break;
+        case "season":
+            $mediaTitle = $clients['parentTitle']; // Season Title
+            pmp_Logging("getTVShowData", "mediaTitle @ Season (parentTitle) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            break;
+        case "series":
+            $mediaTitle = $clients['grandparentTitle']; // Series Title
+            pmp_Logging("getTVShowData", "mediaTitle @ Series (grandparentTitle) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            break;
+        case "movie":
+            $mediaTitle = $clients['title']; // Movie Title
+            pmp_Logging("getMovieData", "mediaTitle @ Movie (title) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            break;
+        case "track":
+            $mediaTitle = $clients['title']; // Track Title (future - title, parentTitle (Album), grandparentTitle (Artist))
+            pmp_Logging("getMusicData", "mediaTitle @ Track (title) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            break;
+        default:
+            $mediaTitle = $clients['title']; // Default Title
+            pmp_Logging("getTVShowData", "mediaTitle @ Default (title) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+    }
+}
+
+function plex_metadata_summary($mediaType = "episode") {
+    global $mediaSummary, $mediaSummary_MetadataID, $clients;
+
+    // Summary
+    switch ($mediaType) {
+        case "episode":
+            $mediaSummary = $clients['summary']; // Episode Summary
+            pmp_Logging("getTVShowData", "mediaSummary @ Episode (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            break;
+        case "season":
+            $mediaSummary = $clients['summary']; // Season Summary
+            pmp_Logging("getTVShowData", "mediaSummary @ Season (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            break;
+        case "series":
+            $mediaSummary = $clients['summary']; // Series Summary
+            pmp_Logging("getTVShowData", "mediaSummary @ Series (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            break;
+        case "movie":
+            $mediaSummary = $clients['summary']; // Movie Summary
+            pmp_Logging("getMovieData", "mediaSummary @ Movie (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            break;
+        case "track":
+            $mediaSummary = $clients['summary']; // Track Summary
+            pmp_Logging("getMusicData", "mediaSummary @ Track (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            break;
+        default:
+            $mediaSummary = $clients['summary']; // Default Summary
+            pmp_Logging("getTVShowData", "mediaSummary @ Default (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+    }
+}
+
+function plex_metadata_tagline($mediaType = "episode") {
+    global $mediaTagline, $mediaTagline_MetadataID, $clients;
+
+    // Notes: TV Shows do not contain tagline
+
+    // Tagline
+    switch ($mediaType) {
+        case "episode":
+            $mediaTagline = $clients['tagline']; // Episode Tagline
+            pmp_Logging("getTVShowData", "mediaTagline @ Episode (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            break;
+        case "season":
+            $mediaTagline = $clients['tagline']; // Season Tagline
+            pmp_Logging("getTVShowData", "mediaTagline @ Season (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            break;
+        case "series":
+            $mediaTagline = $clients['tagline']; // Series Tagline
+            pmp_Logging("getTVShowData", "mediaTagline @ Series (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            break;
+        case "movie":
+            $mediaTagline = $clients['tagline']; // Movie Tagline
+            pmp_Logging("getMovieData", "mediaTagline @ Movie (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            break;
+        case "track":
+            $mediaTagline = $clients['tagline']; // Track Tagline
+            pmp_Logging("getMusicData", "mediaTagline @ Track (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            break;
+        default:
+            $mediaTagline = $clients['tagline']; // Default Tagline
+            pmp_Logging("getTVShowData", "mediaTagline @ Default (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+    }
+}
+
+function plex_metadata_art($mediaType = "episode") {
+    global $mediaArt, $mediaArt_MetadataID, $clients;
+
+    // Art
+    switch ($mediaType) {
+        case "episode":
+            $mediaArt = $clients['art']; // Episode Background Art
+            pmp_Logging("getTVShowData", "mediaArt @ Episode (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            break;
+        case "season":
+            $mediaArt = $clients['art']; // Season Background Art
+            pmp_Logging("getTVShowData", "mediaArt @ Season (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            break;
+        case "series":
+            $mediaArt = $clients['grandparentArt']; // Series Background Art
+            pmp_Logging("getTVShowData", "mediaArt @ Series (grandparentArt) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            break;
+        case "movie":
+            $mediaArt = $clients['art']; // Movie Background Art
+            pmp_Logging("getMovieData", "mediaArt @ Movie (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            break;
+        case "track":
+            $mediaArt = $clients['art']; // Track Background Art
+            pmp_Logging("getMusicData", "mediaArt @ Track (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            break;
+        default:
+            $mediaArt = $clients['art']; // Default Background Art
+            pmp_Logging("getTVShowData", "mediaArt @ Default (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+    }
+}
+
+function plex_metadata_thumb($mediaType = "episode") {
+    global $mediaThumb, $mediaThumb_MetadataID, $clients;
+
+    // Thumb
+    switch ($mediaType) {
+        case "episode":
+            $mediaThumb = $clients['thumb']; // Episode Thumb (Poster)
+            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
+            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
+            pmp_Logging("getTVShowData", "mediaThumb @ Episode (thumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            break;
+        case "season":
+            $mediaThumb = $clients['parentThumb']; // Season Thumb (Poster)
+            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
+            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
+            pmp_Logging("getTVShowData", "mediaThumb @ Season (parentThumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            break;
+        case "series":
+            $mediaThumb = $clients['grandparentThumb']; // Series Thumb (Poster)
+            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
+            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
+            pmp_Logging("getTVShowData", "mediaThumb @ Series (grandparentThumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            break;
+        case "movie":
+            $mediaThumb = $clients['thumb']; // Movie Thumb (Poster)
+            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
+            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
+            pmp_Logging("getMovieData", "mediaThumb @ Movie (thumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            break;
+        case "track":
+            $mediaThumb = $clients['thumb']; // Track Thumb (Poster) (future - thumb, parentThumb (Album), grandparentThumb (Artist))
+            $mediaThumb_Note = "thumb";
+
+            if ($mediaThumb == '') {
+                $mediaThumb = $clients['parentThumb']; // Track Thumb (Poster) (future - thumb, parentThumb (Album), grandparentThumb (Artist))
+                $mediaThumb_Note = "parentThumb";
+            }
+
+            if ($mediaThumb == '') {
+                $mediaThumb = $clients['grandparentThumb']; // Track Thumb (Poster) (future - thumb, parentThumb (Album), grandparentThumb (Artist))
+                $mediaThumb_Note = "grandparentThumb";
+            }
+
+            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
+            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
+            pmp_Logging("getMusicData", "mediaThumb @ Track ($mediaThumb_Note) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            break;
+        default:
+            $mediaThumb = $clients['thumb']; // Default Thumb (Poster)
+            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
+            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
+            pmp_Logging("getTVShowData", "mediaThumb @ Default (thumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+    }
+}
+
+function plex_metadata_template($mediaType = "episode") {
+    global $mediaTitle, $clients;
+
+    // Template
+    // switch ($mediaType) {
+    //     case "episode":
+
+    //         break;
+    //     case "season":
+
+    //         break;
+    //     case "series":
+
+    //         break;
+    //     case "movie":
+
+    //         break;
+    //     default:
+
+    // }
+}
+
+function plex_random_media($mediaAttempt = 0) {
+    global $URLScheme, $plexServer, $comingSoonShowSelection, $plexToken;
+    global $plexServerMovieSection, $plexServerMovieSections, $plexServerMovieSection_ID ;
+    global $useSection, $xmlMedia, $viewGroup;
+
+    pmp_Logging("getMediaURL", "\n"); // New Line
+    pmp_Logging("getMediaURL", "plex_random_media (attempt): $mediaAttempt");
+
+    $plexServerMovieSections = explode(",", $plexServerMovieSection);
+
+    $ValidateSections = implode(",", $plexServerMovieSections);
+    pmp_Logging("getMediaURL", "Library (Array Scan/ReScan): $ValidateSections");
+
+    $useSection = rand(0, count($plexServerMovieSections) - 1);
+    $plexServerMovieSection_ID = $plexServerMovieSections[$useSection];
+    pmp_Logging("getMediaURL", "Library (ID): $plexServerMovieSection_ID");
+
+    $MoviesURL = $URLScheme . '://' . $plexServer . ':32400/library/sections/' . $plexServerMovieSections[$useSection] . '/' . $comingSoonShowSelection . '?X-Plex-Token=' . $plexToken . '';
+    pmp_Logging("getMediaURL", "$comingSoonShowSelection URL: $MoviesURL");
+
+    $getMovies = file_get_contents($MoviesURL);
+    $xmlMedia = simplexml_load_string($getMovies) or die("feed not loading");
+
+    $viewGroup = $xmlMedia['viewGroup'];
+    pmp_Logging("getMediaURL", "xml viewGroup: $viewGroup");
+
+}
+
+?>

--- a/assets/plexmovieposter/PlexLib.php
+++ b/assets/plexmovieposter/PlexLib.php
@@ -3,184 +3,232 @@
 //  NEED TO SUPPORT "movie" and "show" as well as "clients"
 
 function plex_metadata_title($mediaType = "episode") {
-    global $mediaTitle, $mediaTitle_MetadataID, $clients;
+    global $clients;
+    global $mediaTitle, $mediaTitle_MetadataID;
+
+    $media_MetadataID_STR = "";
 
     // Title
     switch ($mediaType) {
         case "episode":
-            $mediaTitle = $clients['title']; // Episode Title
-            pmp_Logging("getTVShowData", "mediaTitle @ Episode (title) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            $media_metadata_name = 'title';
+            $media_logClass = "getTVShowData";
             break;
         case "season":
-            $mediaTitle = $clients['parentTitle']; // Season Title
-            pmp_Logging("getTVShowData", "mediaTitle @ Season (parentTitle) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            $media_metadata_name = 'parentTitle';
+            $media_logClass = "getTVShowData";
             break;
         case "series":
-            $mediaTitle = $clients['grandparentTitle']; // Series Title
-            pmp_Logging("getTVShowData", "mediaTitle @ Series (grandparentTitle) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            $media_metadata_name = 'grandparentTitle';
+            $media_logClass = "getTVShowData";
             break;
         case "movie":
-            $mediaTitle = $clients['title']; // Movie Title
-            pmp_Logging("getMovieData", "mediaTitle @ Movie (title) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            $media_metadata_name = 'title';
+            $media_logClass = "getMovieData";
             break;
         case "track":
-            $mediaTitle = $clients['title']; // Track Title (future - title, parentTitle (Album), grandparentTitle (Artist))
-            pmp_Logging("getMusicData", "mediaTitle @ Track (title) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            $media_metadata_name = 'title'; // Track Title (future - title, parentTitle (Album), grandparentTitle (Artist))
+            $media_logClass = "getMusicData";
             break;
         default:
-            $mediaTitle = $clients['title']; // Default Title
-            pmp_Logging("getTVShowData", "mediaTitle @ Default (title) - $mediaTitle (metadata ID: $mediaTitle_MetadataID)");
+            $media_metadata_name = 'title';
+            $media_logClass = "getTVShowData";
     }
+
+    $mediaTitle = $clients[$media_metadata_name];
+
+    // $media_MetadataID_TMP = preg_split("#/#", $mediaTitle);
+    // $media_MetadataID = $media_MetadataID_TMP[3];
+    // $media_MetadataID_STR = "(metadata ID: $media_MetadataID)";
+
+    // $mediaTitle_MetadataID = $media_MetadataID;
+    pmp_Logging("$media_logClass", "mediaTitle @ $mediaType ($media_metadata_name) $media_MetadataID_STR - $mediaTitle");
 }
 
 function plex_metadata_summary($mediaType = "episode") {
-    global $mediaSummary, $mediaSummary_MetadataID, $clients;
+    global $clients;
+    global $mediaSummary, $mediaSummary_MetadataID;
+
+    $media_MetadataID_STR = "";
 
     // Summary
     switch ($mediaType) {
         case "episode":
-            $mediaSummary = $clients['summary']; // Episode Summary
-            pmp_Logging("getTVShowData", "mediaSummary @ Episode (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            $media_metadata_name = 'summary';
+            $media_logClass = "getTVShowData";
             break;
         case "season":
-            $mediaSummary = $clients['summary']; // Season Summary
-            pmp_Logging("getTVShowData", "mediaSummary @ Season (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            $media_metadata_name = 'summary';
+            $media_logClass = "getTVShowData";
             break;
         case "series":
-            $mediaSummary = $clients['summary']; // Series Summary
-            pmp_Logging("getTVShowData", "mediaSummary @ Series (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            $media_metadata_name = 'summary';
+            $media_logClass = "getTVShowData";
             break;
         case "movie":
-            $mediaSummary = $clients['summary']; // Movie Summary
-            pmp_Logging("getMovieData", "mediaSummary @ Movie (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            $media_metadata_name = 'summary';
+            $media_logClass = "getMovieData";
             break;
         case "track":
-            $mediaSummary = $clients['summary']; // Track Summary
-            pmp_Logging("getMusicData", "mediaSummary @ Track (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            $media_metadata_name = 'summary';
+            $media_logClass = "getMusicData";
             break;
         default:
-            $mediaSummary = $clients['summary']; // Default Summary
-            pmp_Logging("getTVShowData", "mediaSummary @ Default (summary) - $mediaSummary (metadata ID: $mediaSummary_MetadataID)");
+            $media_metadata_name = 'summary';
+            $media_logClass = "getTVShowData";
     }
+
+    $mediaSummary = $clients[$media_metadata_name];
+
+    // $media_MetadataID_TMP = preg_split("#/#", $mediaSummary);
+    // $media_MetadataID = $media_MetadataID_TMP[3];
+    // $media_MetadataID_STR = "(metadata ID: $media_MetadataID)";
+
+    // $mediaSummary_MetadataID = $media_MetadataID;
+    pmp_Logging("$media_logClass", "mediaSummary @ $mediaType ($media_metadata_name) $media_MetadataID_STR - \n $mediaSummary");
 }
 
 function plex_metadata_tagline($mediaType = "episode") {
-    global $mediaTagline, $mediaTagline_MetadataID, $clients;
+    global $clients;
+    global $mediaTagline, $mediaTagline_MetadataID;
+
+    $media_MetadataID_STR = "";
 
     // Notes: TV Shows do not contain tagline
 
     // Tagline
     switch ($mediaType) {
         case "episode":
-            $mediaTagline = $clients['tagline']; // Episode Tagline
-            pmp_Logging("getTVShowData", "mediaTagline @ Episode (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            $media_metadata_name = 'tagline';
+            $media_logClass = "getTVShowData";
             break;
         case "season":
-            $mediaTagline = $clients['tagline']; // Season Tagline
-            pmp_Logging("getTVShowData", "mediaTagline @ Season (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            $media_metadata_name = 'tagline';
+            $media_logClass = "getTVShowData";
             break;
         case "series":
-            $mediaTagline = $clients['tagline']; // Series Tagline
-            pmp_Logging("getTVShowData", "mediaTagline @ Series (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            $media_metadata_name = 'tagline';
+            $media_logClass = "getTVShowData";
             break;
         case "movie":
-            $mediaTagline = $clients['tagline']; // Movie Tagline
-            pmp_Logging("getMovieData", "mediaTagline @ Movie (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            $media_metadata_name = 'tagline';
+            $media_logClass = "getMovieData";
             break;
         case "track":
-            $mediaTagline = $clients['tagline']; // Track Tagline
-            pmp_Logging("getMusicData", "mediaTagline @ Track (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            $media_metadata_name = 'tagline';
+            $media_logClass = "getMusicData";
             break;
         default:
-            $mediaTagline = $clients['tagline']; // Default Tagline
-            pmp_Logging("getTVShowData", "mediaTagline @ Default (tagline) - $mediaTagline (metadata ID: $mediaTagline_MetadataID)");
+            $media_metadata_name = 'tagline';
+            $media_logClass = "getTVShowData";
     }
+
+    $mediaTagline = $clients[$media_metadata_name];
+
+    // $media_MetadataID_TMP = preg_split("#/#", $mediaTagline);
+    // $media_MetadataID = $media_MetadataID_TMP[3];
+    // $media_MetadataID_STR = "(metadata ID: $media_MetadataID)";
+
+    // $mediaTagline_MetadataID = $media_MetadataID;
+    pmp_Logging("$media_logClass", "mediaTagline @ $mediaType ($media_metadata_name) $media_MetadataID_STR - \n $mediaTagline");
 }
 
 function plex_metadata_art($mediaType = "episode") {
-    global $mediaArt, $mediaArt_MetadataID, $clients;
+    global $clients;
+    global $mediaArt, $mediaArt_MetadataID;
+
+    $media_MetadataID_STR = "";
 
     // Art
     switch ($mediaType) {
         case "episode":
-            $mediaArt = $clients['art']; // Episode Background Art
-            pmp_Logging("getTVShowData", "mediaArt @ Episode (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            $media_metadata_name = 'art';
+            $media_logClass = "getTVShowData";
             break;
         case "season":
-            $mediaArt = $clients['art']; // Season Background Art
-            pmp_Logging("getTVShowData", "mediaArt @ Season (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            $media_metadata_name = 'art';
+            $media_logClass = "getTVShowData";
             break;
         case "series":
-            $mediaArt = $clients['grandparentArt']; // Series Background Art
-            pmp_Logging("getTVShowData", "mediaArt @ Series (grandparentArt) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            $media_metadata_name = 'art';
+            $media_logClass = "getTVShowData";
             break;
         case "movie":
-            $mediaArt = $clients['art']; // Movie Background Art
-            pmp_Logging("getMovieData", "mediaArt @ Movie (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            $media_metadata_name = 'art';
+            $media_logClass = "getMovieData";
             break;
         case "track":
-            $mediaArt = $clients['art']; // Track Background Art
-            pmp_Logging("getMusicData", "mediaArt @ Track (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            $media_metadata_name = 'art';
+            $media_logClass = "getMusicData";
             break;
         default:
-            $mediaArt = $clients['art']; // Default Background Art
-            pmp_Logging("getTVShowData", "mediaArt @ Default (art) - $mediaArt (metadata ID: $mediaArt_MetadataID)");
+            $media_metadata_name = 'art';
+            $media_logClass = "getTVShowData";
     }
+
+    $mediaArt = $clients[$media_metadata_name];
+
+    $media_MetadataID_TMP = preg_split("#/#", $mediaArt);
+    $media_MetadataID = $media_MetadataID_TMP[3];
+    $media_MetadataID_STR = "(metadata ID: $media_MetadataID)";
+
+    $mediaArt_MetadataID = $media_MetadataID;
+    pmp_Logging("$media_logClass", "mediaArt @ $mediaType ($media_metadata_name) $media_MetadataID_STR - $mediaArt");
 }
 
 function plex_metadata_thumb($mediaType = "episode") {
-    global $mediaThumb, $mediaThumb_MetadataID, $clients;
+    global $clients;
+    global $mediaThumb, $mediaThumb_MetadataID;
+
+    $media_MetadataID_STR = "";
 
     // Thumb
     switch ($mediaType) {
         case "episode":
-            $mediaThumb = $clients['thumb']; // Episode Thumb (Poster)
-            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
-            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
-            pmp_Logging("getTVShowData", "mediaThumb @ Episode (thumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            $media_metadata_name = 'thumb';
+            $media_logClass = "getTVShowData";
             break;
         case "season":
-            $mediaThumb = $clients['parentThumb']; // Season Thumb (Poster)
-            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
-            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
-            pmp_Logging("getTVShowData", "mediaThumb @ Season (parentThumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            $media_metadata_name = 'parentThumb';
+            $media_logClass = "getTVShowData";
             break;
         case "series":
-            $mediaThumb = $clients['grandparentThumb']; // Series Thumb (Poster)
-            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
-            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
-            pmp_Logging("getTVShowData", "mediaThumb @ Series (grandparentThumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            $media_metadata_name = 'grandparentThumb';
+            $media_logClass = "getTVShowData";
             break;
         case "movie":
-            $mediaThumb = $clients['thumb']; // Movie Thumb (Poster)
-            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
-            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
-            pmp_Logging("getMovieData", "mediaThumb @ Movie (thumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            $media_metadata_name = 'thumb';
+            $media_logClass = "getMovieData";
             break;
         case "track":
-            $mediaThumb = $clients['thumb']; // Track Thumb (Poster) (future - thumb, parentThumb (Album), grandparentThumb (Artist))
-            $mediaThumb_Note = "thumb";
+            $media_metadata_name = 'thumb'; // Track Thumb (Poster) (future - thumb, parentThumb (Album), grandparentThumb (Artist))
+            $media_logClass = "getMusicData";
+
+            $mediaThumb = $clients[$media_metadata_name];
 
             if ($mediaThumb == '') {
-                $mediaThumb = $clients['parentThumb']; // Track Thumb (Poster) (future - thumb, parentThumb (Album), grandparentThumb (Artist))
-                $mediaThumb_Note = "parentThumb";
+                $media_metadata_name = 'parentThumb';
+                $mediaThumb = $clients[$media_metadata_name];
             }
 
             if ($mediaThumb == '') {
-                $mediaThumb = $clients['grandparentThumb']; // Track Thumb (Poster) (future - thumb, parentThumb (Album), grandparentThumb (Artist))
-                $mediaThumb_Note = "grandparentThumb";
+                $media_metadata_name = 'grandparentThumb';
+                $mediaThumb = $clients[$media_metadata_name];
             }
-
-            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
-            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
-            pmp_Logging("getMusicData", "mediaThumb @ Track ($mediaThumb_Note) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
             break;
         default:
-            $mediaThumb = $clients['thumb']; // Default Thumb (Poster)
-            $mediaThumb_TMP = preg_split("#/#", $mediaThumb);
-            $mediaThumb_MetadataID = $mediaThumb_TMP[3];
-            pmp_Logging("getTVShowData", "mediaThumb @ Default (thumb) - $mediaThumb (metadata ID: $mediaThumb_MetadataID)");
+            $media_metadata_name = 'thumb';
+            $media_logClass = "getTVShowData";
     }
+
+    $mediaThumb = $clients[$media_metadata_name];
+
+    $media_MetadataID_TMP = preg_split("#/#", $mediaThumb);
+    $media_MetadataID = $media_MetadataID_TMP[3];
+    $media_MetadataID_STR = "(metadata ID: $media_MetadataID)";
+
+    $mediaThumb_MetadataID = $media_MetadataID;
+    pmp_Logging("$media_logClass", "mediaTagline @ $mediaType ($media_metadata_name) $media_MetadataID_STR - $mediaThumb");
 }
 
 function plex_metadata_template($mediaType = "episode") {
@@ -231,6 +279,115 @@ function plex_random_media($mediaAttempt = 0) {
     $viewGroup = $xmlMedia['viewGroup'];
     pmp_Logging("getMediaURL", "xml viewGroup: $viewGroup");
 
+}
+
+function plex_variable_presets($mode = "comingSoon") {
+    $topSelection_test = ${$mode . "Top"};
+    pmp_Logging("getMediaURL", "GenVar: $topSelection_test");
+    // $autoScaleTop = $comingSoonTopAutoScale;
+    // $topColor = $comingSoonTopFontColor;
+    // $topSize = $comingSoonTopFontSize;
+    // $topFontEnabled = $comingSoonTopFontEnabled;
+    // $topFontID = $comingSoonTopFontID;
+
+    // $bottomSelection = $comingSoonBottom;
+    // $autoScaleBottom = $comingSoonBottomAutoScale;
+    // $bottomColor = $comingSoonBottomFontColor;
+    // $bottomSize = $comingSoonBottomFontSize;
+    // $bottomFontEnabled = $comingSoonBottomFontEnabled;
+    // $bottomFontID = $comingSoonBottomFontID;
+
+    // $mediaArt_Status = $comingSoonBackgroundArt;
+    // $mediaArt_ShowTVThumb = $comingSoonShowTVThumb;
+
+
+}
+
+function plex_getMedia_thumb() {
+    // Media Thumb (Poster)
+    global $URLScheme, $plexServer, $plexToken, $cachePath, $cacheEnabled; // Input Variables
+    global $mediaThumb, $mediaThumb_MetadataID; // Input Variables
+    global $mediaThumb_Display; // Output Variables
+
+    // $mediaThumb_ID, $mediaThumb_CacheFileName, $mediaThumb_CacheFullName, $mediaThumb_URL, $mediaThumb_CacheURL; // Internal Variables
+
+    // Check if the cache option is enabled, and if so set the name of the saved file and store in the designated cache path.
+    if ($cacheEnabled) {
+        $mediaThumb_ID = explode("/", $mediaThumb);
+        $mediaThumb_ID = trim($mediaThumb_ID[count($mediaThumb_ID) - 1], '/');
+
+        if (!isset($mediaThumb_MetadataID) || trim($mediaThumb_MetadataID) === '') {
+            $mediaThumb_CacheFileName = $mediaThumb_ID;
+        } else {
+            $mediaThumb_CacheFileName = $mediaThumb_ID . "_" . $mediaThumb_MetadataID;
+        }
+
+        $mediaThumb_CacheFullName = join('/', array(trim($cachePath, '/'), trim($mediaThumb_CacheFileName, '/')));
+        pmp_Logging("getCacheFile", "Cache File @ Output (mediaThumb) - $mediaThumb_CacheFullName");
+
+        $mediaThumb_URL = "$URLScheme://$plexServer:32400$mediaThumb?X-Plex-Token=$plexToken";
+        pmp_Logging("getMediaThumb", "$mediaThumb_ID ($cachePath) - $mediaThumb_URL");
+
+        // There's nothing else to do here, just save it
+        if (!file_exists($mediaThumb_CacheFullName)) {
+            file_put_contents("$mediaThumb_CacheFullName", fopen("$mediaThumb_URL", 'r'));
+        }
+
+        $mediaThumb_CacheURL = $mediaThumb_CacheFullName;
+
+        // $mediaThumb_Display = "url('$mediaThumb_CacheURL')"; // Unsecure URL
+        $mediaThumb_Display = "url('data:image/jpeg;base64,".getCachePoster($mediaThumb_CacheURL)."')"; // Secure URL
+        // pmp_Logging("getMediaThumb", "mediaThumb (Display - Secure) - $mediaThumb_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
+    } else {
+        // $mediaThumb_Display = "url('$URLScheme://$plexServer:32400$mediaThumb?X-Plex-Token=$plexToken')"; // Unsecure URL
+        $mediaThumb_Display = "url('data:image/jpeg;base64,".getPoster($mediaThumb)."')"; // Secure URL
+        // pmp_Logging("getMediaThumb", "mediaThumb (Display - Secure) - $mediaThumb_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
+    }
+}
+
+function plex_getMedia_art() {
+    // Media Art (Background)
+    global $URLScheme, $plexServer, $plexToken, $cacheArtPath, $cacheEnabled; // Input Variables
+    global $mediaArt, $mediaArt_MetadataID; // Input Variables
+    global $mediaArt_Display; // Output Variables
+
+    // $mediaArt_ID, $mediaArt_CacheFileName, $mediaArt_CacheFullName, $mediaArt_URL, $mediaArt_CacheURL; // Internal Variables
+
+    // Check if the cache option is enabled, and if so set the name of the saved file and store in the designated cache path.
+    if ($cacheEnabled) {
+        $mediaArt_ID = explode("/", $mediaArt);
+        $mediaArt_ID = trim($mediaArt_ID[count($mediaArt_ID) - 1], '/');
+
+        // If there is no mediaArt then the media art will be skipped, and background will revert to default.
+        if (isset($mediaArt_ID) && trim($mediaArt_ID) != '') {
+            if (!isset($mediaArt_MetadataID) || trim($mediaArt_MetadataID) === '') {
+                $mediaArt_CacheFileName = $mediaArt_ID;
+            } else {
+                $mediaArt_CacheFileName = $mediaArt_ID . "_" . $mediaArt_MetadataID;
+            }
+
+            $mediaArt_CacheFullName = join('/', array(trim($cacheArtPath, '/'), trim($mediaArt_CacheFileName, '/')));
+            pmp_Logging("getCacheFile", "Cache File @ Output (mediaArt) - $mediaArt_CacheFullName");
+
+            $mediaArt_URL = "$URLScheme://$plexServer:32400$mediaArt?X-Plex-Token=$plexToken";
+            pmp_Logging("getMediaArt", "$mediaArt_ID ($cacheArtPath) - $mediaArt_URL");
+
+            // There's nothing else to do here, just save it
+            if (!file_exists($mediaArt_CacheFullName)) {
+                file_put_contents("$mediaArt_CacheFullName", fopen("$mediaArt_URL", 'r'));
+            }
+
+            $mediaArt_CacheURL = $mediaArt_CacheFullName;
+
+            // $mediaArt_Display = "url('$mediaArt_CacheURL')"; // Unsecure URL
+            $mediaArt_Display = "url('data:image/jpeg;base64,".getCachePoster($mediaArt_CacheURL)."')"; // Secure URL
+            // pmp_Logging("getMediaArt", "mediaArt (Display - Secure) - $mediaArt_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
+        }
+    } else {
+         // $mediaArt_Display = "url('$URLScheme://$plexServer:32400$mediaArt?X-Plex-Token=$plexToken')"; // Unsecure URL
+         $mediaArt_Display = "url('data:image/jpeg;base64,".getPoster($mediaArt)."')"; // Secure URL
+         // pmp_Logging("getMediaArt", "mediaArt (Display - Secure) - $mediaArt_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
+    }
 }
 
 ?>

--- a/assets/plexmovieposter/setData.php
+++ b/assets/plexmovieposter/setData.php
@@ -117,6 +117,9 @@ function ghostData($configPage) {
         $ghostField = "$formIndent<input type=\"hidden\" id=\"comingSoonShowSelection\" name=\"comingSoonShowSelection\" value=\"$comingSoonShowSelection\">\n";
         echo $ghostField;
 
+        $ghostField = "$formIndent<input type=\"hidden\" id=\"comingSoonShowTVThumb\" name=\"comingSoonShowTVThumb\" value=\"$comingSoonShowTVThumb\">\n";
+        echo $ghostField;
+
         $ghostField = "$formIndent<input type=\"hidden\" id=\"comingSoonTop\" name=\"comingSoonTop\" value=\"$comingSoonTop\">\n";
         echo $ghostField;
 
@@ -181,6 +184,9 @@ function ghostData($configPage) {
         echo $ghostField;
 
         $ghostField = "$formIndent<input type=\"hidden\" id=\"nowShowingBackgroundArt\" name=\"nowShowingBackgroundArt\" value=\"$nowShowingBackgroundArt\">\n";
+        echo $ghostField;
+        
+        $ghostField = "$formIndent<input type=\"hidden\" id=\"nowShowingShowTVThumb\" name=\"nowShowingShowTVThumb\" value=\"$nowShowingShowTVThumb\">\n";
         echo $ghostField;
 
         $ghostField = "$formIndent<input type=\"hidden\" id=\"nowShowingTop\" name=\"nowShowingTop\" value=\"$nowShowingTop\">\n";
@@ -395,6 +401,7 @@ function setData($configPage) {
   \$comingSoonBottomFontOutlineSize = '$_POST[comingSoonBottomFontOutlineSize]'; //Default: 0 (px)
   \$comingSoonBottomFontOutlineColor = '$_POST[comingSoonBottomFontOutlineColor]'; //Default: #FFFFFF (White)
   \$comingSoonShowSelection = '$_POST[comingSoonShowSelection]'; //Default: unwatched
+  \$comingSoonShowTVThumb = '$_POST[comingSoonShowTVThumb]'; //Default: series
 
   //Now Showing Configuration
   \$nowShowingBackgroundArt = '$_POST[nowShowingBackgroundArt]'; //Default: false
@@ -416,6 +423,7 @@ function setData($configPage) {
   \$nowShowingBottomFontID = '$_POST[nowShowingBottomFontID]';
   \$nowShowingBottomFontOutlineSize = '$_POST[nowShowingBottomFontOutlineSize]'; //Default: 0 (px)
   \$nowShowingBottomFontOutlineColor = '$_POST[nowShowingBottomFontOutlineColor]'; //Default: #FFFFFF (White)
+  \$nowShowingShowTVThumb = '$_POST[nowShowingShowTVThumb]'; //Default: series
 
   //Misc Configuration
   \$pmpDisplayProgress = '$_POST[pmpDisplayProgress]'; //Default: Disabled

--- a/assets/plexmovieposter/sysConfig.php
+++ b/assets/plexmovieposter/sysConfig.php
@@ -2,8 +2,14 @@
   //Logging
   $LogPath = "";
   $Log_getPoster = FALSE;
+  $Log_getCachePoster = FALSE;
+  $Log_getCacheFile = TRUE;
   $Log_getMediaArt = TRUE;
   $Log_getMediaThumb = TRUE;
   $Log_getIndex = TRUE;
+  $Log_getTVShowData = TRUE;
+  $Log_getMovieData = TRUE;
+  $Log_getMusicData = TRUE;
+  $Log_getMediaURL = TRUE;
 
 ?>

--- a/assets/styles/default/poster.css
+++ b/assets/styles/default/poster.css
@@ -19,6 +19,22 @@ body {
   left: 0;
 }
 
+.mediaArt {
+  /* The image used */
+  /*background-image: url(""); */
+
+  /* Add the blur effect */
+  filter: blur(8px);
+  -webkit-filter: blur(8px);                                                                                                                                                                                                                      /* Full height */
+  height: 100%;
+
+  /* Center and scale the image nicely */
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-size: cover;
+  background-position: center;
+}
+
 .alert {
   position: absolute;
   width: 100%;

--- a/build/DockerSetup.config
+++ b/build/DockerSetup.config
@@ -1,15 +1,16 @@
 [DEFAULT]
-PortExternal = 80
-PortInternal = 80
-OSPlatform = linux
-imageNameRoot = plexmovieposterdisplay
-tag = 2.8.1
-DockerfileRoot = ../.
-ImageType = 
-NetworkType = 
-noCache = False
+portexternal = 80
+portinternal = 80
+osplatform = linux
+imagenameroot = plexmovieposterdisplay
+tag = 2.9.0
+dockerfileroot = ../.
+imagetype = 
+networktype = 
+nocache = False
 
 [PLEX]
-PLEX_TOKEN = 
-PLEX_SERVER_IP = 
-PLEX_MOVIE_SECTIONS = 
+plex_token = 
+plex_server_ip = 
+plex_movie_sections = 
+

--- a/build/UpdateVersion.py
+++ b/build/UpdateVersion.py
@@ -1,0 +1,93 @@
+import os
+import io
+import configparser
+import yaml # pip3 install pyyaml
+import re
+
+def UpdateINI(DisplayMSG=False,ConfigSegment="DEFAULT",ConfigKey="tag",ConfigValue="",ConfigFile="config.ini"):
+    # SETTINGS
+    ConfigFile_FullName = os.path.join(PYScriptRoot,ConfigFile)
+    ConfigFile_Data = configparser.RawConfigParser(allow_no_value=True)
+    ConfigFile_Data.read(ConfigFile_FullName)
+    ConfigFile_Data.optionxform=str
+
+    # READ
+    ReadElement = ConfigFile_Data.get(ConfigSegment, ConfigKey)
+
+    if DisplayMSG == True:
+        print("Read Value [{}]: {}".format(ConfigKey,ReadElement))
+
+    # UPDATE
+    ConfigFile_Data.set(ConfigSegment, ConfigKey, ConfigValue)
+
+    if DisplayMSG == True:
+        print ("Segment [{}]: {} ({}) Updated".format(ConfigSegment,ConfigKey,ConfigValue))
+
+    # WRITE
+    with open(ConfigFile_FullName, 'w') as configfile:
+        ConfigFile_Data.write(configfile)
+
+def UpdateYAML(DisplayMSG=False,ConfigSegment="DEFAULT",ConfigKey="next-version",ConfigValue="",ConfigFile="config.yaml"):
+    # SETTINGS
+    ConfigFile_FullName = os.path.join(PYScriptRoot,ConfigFile)
+    
+    # READ
+    with open(ConfigFile_FullName, 'r') as file:
+        ConfigFile_Data = yaml.load(file, Loader=yaml.FullLoader)
+    
+    if DisplayMSG == True:
+        for key, val in ConfigFile_Data.items():
+            print(key, ":", val)
+
+    # UPDATE
+    ConfigFile_Data[ConfigKey] = ConfigValue
+
+    if DisplayMSG == True:
+        for key, val in ConfigFile_Data.items():
+            print(key, ":", val)
+
+    # WRITE
+    with open(ConfigFile_FullName, 'w') as file:
+        ConfigFile_Data = yaml.dump(ConfigFile_Data, file)
+
+def UpdatePHP(DisplayMSG=False,ConfigSegment="DEFAULT",ConfigKey="version",ConfigValue="",ConfigFile="config.php"):
+    # SETTINGS
+    ConfigFile_FullName = os.path.join(PYScriptRoot,ConfigFile)
+
+    # READ
+    with open(ConfigFile_FullName, 'r') as file:
+        ConfigFile_Data = file.read()
+    
+    if DisplayMSG == True:
+        print(ConfigFile_Data)
+
+    # UPDATE
+    ConfigFile_Data_Replace = re.compile('\$'+ ConfigKey + ' =.*;')
+
+    if DisplayMSG == True:
+        print(ConfigFile_Data_Replace)
+
+    # WRITE
+    with open(ConfigFile_FullName, 'r+') as file:
+        data = ConfigFile_Data_Replace.sub('$version = \"' + ConfigValue + '\";', file.read())
+        file.seek(0) # Places the text "Input" in the file at the beginning of the file
+        file.write(data)
+        file.truncate() 
+
+    #This will cause all trailing data to be flushed.
+    # reason for doing this is because your default value of `$limit_value` might
+    # make your total content written back to the file shorter of that was writter before.
+    # there for there might be trailing data we need to truncate away.    
+
+DisplayMSG = False
+SetVersion = "2.9.0"
+
+PYScriptRoot = os.path.abspath(os.path.dirname(__file__))
+
+VersionFile_01 = "DockerSetup.config"
+VersionFile_02 = "../GitVersion.yml"
+VersionFile_03 = "../settings/PMPInfo.php"
+
+UpdateINI(DisplayMSG=DisplayMSG,ConfigFile=VersionFile_01,ConfigValue=SetVersion)
+UpdateYAML(DisplayMSG=DisplayMSG,ConfigFile=VersionFile_02,ConfigValue=SetVersion)
+UpdatePHP(DisplayMSG=DisplayMSG,ConfigFile=VersionFile_03,ConfigValue=SetVersion)

--- a/config.php
+++ b/config.php
@@ -61,6 +61,7 @@
   $comingSoonBottomFontOutlineSize = '0'; //Default: 0 (px)
   $comingSoonBottomFontOutlineColor = '#FFFFFF'; //Default: #FFFFFF (White)
   $comingSoonShowSelection = 'unwatched'; //Default: unwatched
+  $comingSoonShowTVThumb = 'series'; //Default: series
 
   //Now Showing Configuration
   $nowShowingTop = 'custom'; //Default: custom (title/summary/tagline/custom)
@@ -81,6 +82,7 @@
   $nowShowingBottomFontID = '';
   $nowShowingBottomFontOutlineSize = '0'; //Default: 0 (px)
   $nowShowingBottomFontOutlineColor = '#FFFFFF'; //Default: #FFFFFF (White)
+  $nowShowingShowTVThumb = 'series'; //Default: series
 
   //Misc Configuration
   $pmpDisplayProgress = 'Disabled'; //Default: Disabled

--- a/docs/ChangeLogs.md
+++ b/docs/ChangeLogs.md
@@ -68,5 +68,90 @@ GitVersion integration
 **v2.6 Community Updates**\
 New configuration and administration pages
 
-**v2.7 Community Updates**\
-Custom Font Integration
+**v2.7.0 Community Updates**\
+Add integration of Fonts into the Plex Movie Poster system.
+
+Updates - Custom Font Integration (Issue #16)
+- Importing of Fonts (ttf and zip)
+- Exporting of Fonts (zip)
+- Displaying sample of fonts
+- Add list of fonts and configuration for Top/Bottom of Coming Soon, Now Showing, Custom.
+- Option to set font and enable/disable font (per Top/Bottom)
+- Update documentation for Font update.
+- Update Dockerfile to install php-zip as required for import/export functions.
+
+Updates and Bug Fixes:
+- Bump version to v2.7
+- Prep for centralized cache count function
+- Move import/export of config function to importExportLib and minor updates and adjustments.
+- Minor adjustments to cache display format
+- Fix issue with customCache was pulling Poster cache value.
+- Fix issue in Now Showing page that Top/Bottom Auto Scale was pointing to comingSoon variables.
+- Add/Change the footer message. (Resolves #19)
+- Misc. documentation updates.
+- Add PHPInfo file to show PHP version. This is in preparation for upgrade to PHP 8
+- Add (commented out) lines in Dockerfile in preparation for PHP 8
+- Add backup.php (prototype) to backup all custom fonts and config, using date stamp.
+
+Bugs:
+- Color font picker not displaying correctly (known issue from previous release)
+- Sometimes configuration value is not reflected on Save Changes and require a refresh on the page to display the updated values.
+
+**v2.7.1 Community Updates**\
+Address issue when having a TV Show library as part of the library scan, the TV Show metadata is not being read correctly and art is not being displayed for Coming Soon.
+
+Updates (Issue #23):
+- Add read information for metadata of TV Shows for Coming Soon
+- Add support (not configured) to allow for displaying either cover art for Show or Season as part of Now Playing
+- Start documentation for how the media is defined (not linked)
+
+Updates and Bug Fixes:
+- Fix issue with SSL displaying blank page when loading.
+- Add showCacheImgs.php file to display all the images in the poster cache
+- Add logging system to capture log information for debugging
+ 
+**v2.8.0 Community Updates**\
+Updates - Background Theme ~ Backend (Issue #27):
+- getData.php: Update the '$art' var to mediaThumb to better reflect the naming from xml
+- add $pmpArtDir in config for cache path
+- change variable names to more align with XML naming
+
+Updates and Bug Fixes:
+- Extend more logging info
+- refactor cache folder creation and preparation
+
+ToDos:
+- Figure out how to pass mediaArt to index page as the mediaThumb is currently
+- Set background to mediaArt value
+
+**v2.8.1 Community Updates**\
+Updates - Background Theme ~ Frontend (Issue #27):
+- getData.php: Setup data to pass to index.php
+- Add options to turn on/off of Background art for Coming Soon and Now Showing
+- Update bottom css to disable the background color.
+
+Updates and Bug Fixes:
+- Misc. File formatting cleanup
+- Update how setData refreshes the file on save
+
+**v2.9.0 Community Updates**\
+Updates – TV Show Integration (Issue #23):
+- Add new variables: $nowShowingShowTVThumb (Default: series)
+- Add new dropdown in 'Now Showing' (Episode/Series/Season) to set Thumb (Poster)
+- Add new variables: $comingSoonShowTVThumb (Default: series)
+
+Updates - Music Integration (Issue #30):
+- Add check to see if playing video is 'video' or 'track'
+- Add metadata check for 'track'
+
+Updates and Bug Fixes:
+- Create UpdateVersion.py to update all the versions in a single update.
+- Update the url for cache images to use the 'encrypted’ url like the non-cached version (Issue #25)
+- Add Blur to mediaArt (Background) (Issue #27)
+
+ToDos:
+- Add switches to Enable/Disable TV Shows within the 'Coming Soon' and/or 'Now Playing'
+- Add switches to Enable/Disable Music within the 'Coming Soon' and/or 'Now Playing'
+- Add switches to Enable/Disable Thumb (Poster) within the 'Coming Soon' and/or 'Now Playing' - If you only want 'art'
+- Add Music metadata to 'Coming Soon' rotation - Currently shows as blank data
+- Update 'Coming Soon' metadata reader to use PlexLib functions so to share same business logic

--- a/docs/ChangeLogs.md
+++ b/docs/ChangeLogs.md
@@ -109,7 +109,7 @@ Updates and Bug Fixes:
 - Fix issue with SSL displaying blank page when loading.
 - Add showCacheImgs.php file to display all the images in the poster cache
 - Add logging system to capture log information for debugging
- 
+
 **v2.8.0 Community Updates**\
 Updates - Background Theme ~ Backend (Issue #27):
 - getData.php: Update the '$art' var to mediaThumb to better reflect the naming from xml
@@ -148,10 +148,14 @@ Updates and Bug Fixes:
 - Create UpdateVersion.py to update all the versions in a single update.
 - Update the url for cache images to use the 'encrypted’ url like the non-cached version (Issue #25)
 - Add Blur to mediaArt (Background) (Issue #27)
+- Fix issue with background art and poster do not match (Issue #27)
+- Move some actions out of the getData.php to its own PlexLib.php file to split into functions for better organization and scale.
+- Update 'Coming Soon' metadata reader to use PlexLib functions so to share same business logic.
 
 ToDos:
-- Add switches to Enable/Disable TV Shows within the 'Coming Soon' and/or 'Now Playing'
-- Add switches to Enable/Disable Music within the 'Coming Soon' and/or 'Now Playing'
-- Add switches to Enable/Disable Thumb (Poster) within the 'Coming Soon' and/or 'Now Playing' - If you only want 'art'
+- Add switches to Enable/Disable TV Shows within the 'Coming Soon' and/or 'Now Playing' (Issue #23)
+- Add switches to Enable/Disable Music within the 'Coming Soon' and/or 'Now Playing' (Issue #30)
+    - 'Coming Soon' for music does not work when using 'unwatched'; currently music is skipped in this mode.
+- Add switches to Enable/Disable Thumb (Poster) within the 'Coming Soon' and/or 'Now Playing' - If you only want 'art' only
+    - This will also require a small rework to how the blur function works.
 - Add Music metadata to 'Coming Soon' rotation - Currently shows as blank data
-- Update 'Coming Soon' metadata reader to use PlexLib functions so to share same business logic

--- a/getData.php
+++ b/getData.php
@@ -12,8 +12,8 @@ include 'getPoster.php';
 $results = Array();
 $movies = Array();
 $shows = Array();
-// $TVCoverArt_Play = "show";
-// $TVCoverArt_Play = "season";
+// $mediaArt_ShowTVThumb = "show";
+// $mediaArt_ShowTVThumb = "season";
 
 ob_start();
 $data = [];
@@ -165,7 +165,7 @@ if ($customImageEnabled == "Enabled") {
                 $bottomFontID = $nowShowingBottomFontID;
 
                 $mediaArt_Status = $nowShowingBackgroundArt;
-                $TVCoverArt_Play = $nowShowingShowTVThumb;
+                $mediaArt_ShowTVThumb = $nowShowingShowTVThumb;
 
                 $mediaTitle = $clients['title']; // Default
                 $mediaTagline = $clients['tagline']; // Default
@@ -184,11 +184,11 @@ if ($customImageEnabled == "Enabled") {
                         plex_metadata_thumb("movie");
                         break;
                     case "episode":
-                        plex_metadata_title($TVCoverArt_Play);
-                        plex_metadata_summary($TVCoverArt_Play);
-                        plex_metadata_tagline($TVCoverArt_Play);
-                        plex_metadata_art($TVCoverArt_Play);
-                        plex_metadata_thumb($TVCoverArt_Play);
+                        plex_metadata_title($mediaArt_ShowTVThumb);
+                        plex_metadata_summary($mediaArt_ShowTVThumb);
+                        plex_metadata_tagline($mediaArt_ShowTVThumb);
+                        plex_metadata_art($mediaArt_ShowTVThumb);
+                        plex_metadata_thumb($mediaArt_ShowTVThumb);
                         break;
                     case "track":
                         plex_metadata_title("track");
@@ -223,21 +223,26 @@ if ($customImageEnabled == "Enabled") {
     if (!$isPlaying) {
         //Clean Up Status
         updateStatus();
-        $autoScaleBottom = $comingSoonBottomAutoScale;
+
+        $topSelection = $comingSoonTop;
         $autoScaleTop = $comingSoonTopAutoScale;
         $topColor = $comingSoonTopFontColor;
         $topSize = $comingSoonTopFontSize;
-        $bottomColor = $comingSoonBottomFontColor;
-        $bottomSize = $comingSoonBottomFontSize;
-        $topSelection = $comingSoonTop;
-        $bottomSelection = $comingSoonBottom;
-
         $topFontEnabled = $comingSoonTopFontEnabled;
         $topFontID = $comingSoonTopFontID;
+
+        $bottomSelection = $comingSoonBottom;
+        $autoScaleBottom = $comingSoonBottomAutoScale;
+        $bottomColor = $comingSoonBottomFontColor;
+        $bottomSize = $comingSoonBottomFontSize;
         $bottomFontEnabled = $comingSoonBottomFontEnabled;
         $bottomFontID = $comingSoonBottomFontID;
 
         $mediaArt_Status = $comingSoonBackgroundArt;
+        // $mediaArt_ShowTVThumb = $comingSoonShowTVThumb;
+        $mediaArt_ShowTVThumb = "episode";
+
+        plex_variable_presets(); // FUTURE USE
 
         //Multi Movie Section Support
         plex_random_media(1); // Scan Libraries for Media
@@ -258,33 +263,47 @@ if ($customImageEnabled == "Enabled") {
             }
             $random_keys = array_rand($movies, 1);
             $showMedia = $movies[$random_keys];
+            $moviesCount = count($movies);
+            pmp_Logging("getMediaURL", "Coming Soon (Movies) COUNT: $moviesCount");
 
-            foreach ($xmlMedia->Video as $clients) {
-                if (strstr($clients['title'], $showMedia)) {
-                    plex_metadata_title("movie");
-                    plex_metadata_summary("movie");
-                    plex_metadata_tagline("movie");
-                    plex_metadata_art("movie");
-                    plex_metadata_thumb("movie");
+            if ($moviesCount > '0') {
+                foreach ($xmlMedia->Video as $clients) {
+                    if (strstr($clients['title'], $showMedia)) {
+                        $checkTitle = $clients['title'];
+                        pmp_Logging("getMediaURL", "Coming Soon (Movies): $checkTitle");
+                        plex_metadata_title("movie");
+                        plex_metadata_summary("movie");
+                        plex_metadata_tagline("movie");
+                        plex_metadata_art("movie");
+                        plex_metadata_thumb("movie");
+                    }
                 }
             }
 
             // TV Shows
             foreach ($xmlMedia->Directory as $show) {
                 $shows[] = strip_tags($show['title']);
+
             }
             $random_keys = array_rand($shows, 1);
             $showMedia = $shows[$random_keys];
+            $showsCount = count($shows);
+            pmp_Logging("getMediaURL", "Coming Soon (TV Show) COUNT: $showsCount");
 
-            foreach ($xmlMedia->Directory as $clients) {
-                if (strstr($clients['title'], $showMedia)) {
-                    plex_metadata_title($TVCoverArt_Play);
-                    plex_metadata_summary($TVCoverArt_Play);
-                    plex_metadata_tagline($TVCoverArt_Play);
-                    plex_metadata_art($TVCoverArt_Play);
-                    plex_metadata_thumb($TVCoverArt_Play);
+            if ($showsCount > '0') {
+                foreach ($xmlMedia->Directory as $clients) {
+                    if (strstr($clients['title'], $showMedia)) {
+                        $checkTitle = $clients['title'];
+                        pmp_Logging("getMediaURL", "Coming Soon (TV Show): $checkTitle");
+                        plex_metadata_title($mediaArt_ShowTVThumb);
+                        plex_metadata_summary($mediaArt_ShowTVThumb);
+                        plex_metadata_tagline($mediaArt_ShowTVThumb);
+                        plex_metadata_art($mediaArt_ShowTVThumb);
+                        plex_metadata_thumb($mediaArt_ShowTVThumb);
+                    }
                 }
             }
+
         }
     }
 }
@@ -293,70 +312,12 @@ if ($customImageEnabled == "Enabled") {
 // Otherwise, necessary values are set at the top
 if ($customImageEnabled != "Enabled") {
     // Check to see if we should cache our art
-    if ($cacheEnabled) {
-        // Media Thumb (Poster) - Future: Move into function
-        $mediaThumb_ID = explode("/", $mediaThumb);
-        $mediaThumb_ID = trim($mediaThumb_ID[count($mediaThumb_ID) - 1], '/');
 
-        if (!isset($mediaThumb_MetadataID) || trim($mediaThumb_MetadataID) === '') {
-            $mediaThumb_CacheFileName = $mediaThumb_ID;
-        } else {
-            $mediaThumb_CacheFileName = $mediaThumb_ID . "_" . $mediaThumb_MetadataID;
-        }
-        // $mediaThumb_CacheFullName = $cachePath . $mediaThumb_CacheFileName;
-        $mediaThumb_CacheFullName = join('/', array(trim($cachePath, '/'), trim($mediaThumb_CacheFileName, '/')));
-        pmp_Logging("getCacheFile", "Cache File @ Output (mediaThumb) - $mediaThumb_CacheFullName");
+    // Media Thumb (Poster)
+    plex_getMedia_thumb();
 
-        $mediaThumb_URL = "$URLScheme://$plexServer:32400$mediaThumb?X-Plex-Token=$plexToken";
-        pmp_Logging("getMediaThumb", "$mediaThumb_ID ($cachePath) - $mediaThumb_URL");
-
-        // There's nothing else to do here, just save it
-        if (!file_exists($mediaThumb_CacheFullName)) {
-            file_put_contents("$mediaThumb_CacheFullName", fopen("$mediaThumb_URL", 'r'));
-        }
-
-        $mediaThumb_CacheURL = $mediaThumb_CacheFullName;
-
-        // $mediaThumb_Display = "url('$mediaThumb_CacheURL')"; // Unsecure URL
-        $mediaThumb_Display = "url('data:image/jpeg;base64,".getCachePoster($mediaThumb_CacheURL)."')"; // Secure URL
-        // pmp_Logging("getMediaThumb", "mediaThumb (Display - Secure) - $mediaThumb_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
-
-        // Media Art (Background) - Future: Move into function
-        $mediaArt_ID = explode("/", $mediaArt);
-        $mediaArt_ID = trim($mediaArt_ID[count($mediaArt_ID) - 1], '/');
-
-        if (isset($mediaArt_ID) && trim($mediaArt_ID) != '') {
-            if (!isset($mediaArt_MetadataID) || trim($mediaArt_MetadataID) === '') {
-                $mediaArt_CacheFileName = $mediaArt_ID;
-            } else {
-                $mediaArt_CacheFileName = $mediaArt_ID . "_" . $mediaArt_MetadataID;
-            }
-            $mediaArt_CacheFullName = join('/', array(trim($cacheArtPath, '/'), trim($mediaArt_CacheFileName, '/')));
-            pmp_Logging("getCacheFile", "Cache File @ Output (mediaArt) - $mediaArt_CacheFullName");
-
-            $mediaArt_URL = "$URLScheme://$plexServer:32400$mediaArt?X-Plex-Token=$plexToken";
-            pmp_Logging("getMediaArt", "$mediaArt_ID ($cacheArtPath) - $mediaArt_URL");
-
-            // There's nothing else to do here, just save it
-            if (!file_exists($mediaArt_CacheFullName)) {
-                file_put_contents("$mediaArt_CacheFullName", fopen("$mediaArt_URL", 'r'));
-            }
-
-            $mediaArt_CacheURL = $mediaArt_CacheFullName;
-
-            // $mediaArt_Display = "url('$mediaArt_CacheURL')"; // Unsecure URL
-            $mediaArt_Display = "url('data:image/jpeg;base64,".getCachePoster($mediaArt_CacheURL)."')"; // Secure URL
-            // pmp_Logging("getMediaArt", "mediaArt (Display - Secure) - $mediaArt_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
-        }
-    } else {
-        // $mediaThumb_Display = "url('$URLScheme://$plexServer:32400$mediaThumb?X-Plex-Token=$plexToken')"; // Unsecure URL
-        $mediaThumb_Display = "url('data:image/jpeg;base64,".getPoster($mediaThumb)."')"; // Secure URL
-        // pmp_Logging("getMediaThumb", "mediaThumb (Display - Secure) - $mediaThumb_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
-
-        // $mediaArt_Display = "url('$URLScheme://$plexServer:32400$mediaArt?X-Plex-Token=$plexToken')"; // Unsecure URL
-        $mediaArt_Display = "url('data:image/jpeg;base64,".getPoster($mediaArt)."')"; // Secure URL
-        // pmp_Logging("getMediaArt", "mediaArt (Display - Secure) - $mediaArt_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
-    }
+    // Media Art (Background)
+    plex_getMedia_art();
 
     // Figure out which text goes where
     switch($topSelection) {

--- a/getData.php
+++ b/getData.php
@@ -4,6 +4,7 @@ include 'config.php';
 include 'status.php';
 include 'assets/plexmovieposter/tools.php';
 include 'assets/plexmovieposter/CacheLib.php';
+include 'assets/plexmovieposter/PlexLib.php';
 
 // Security Work Around (quick fix)
 include 'getPoster.php';
@@ -12,7 +13,7 @@ $results = Array();
 $movies = Array();
 $shows = Array();
 // $TVCoverArt_Play = "show";
-$TVCoverArt_Play = "season";
+// $TVCoverArt_Play = "season";
 
 ob_start();
 $data = [];
@@ -40,7 +41,7 @@ if ($pmpBottomScroll == 'Enabled') {
 
 // -------------------------
 // Poster Cache
-$cachePath = $pmpPosterDir; 
+$cachePath = $pmpPosterDir;
 GeneralCache_Prep($cachePath, TRUE);
 // -------------------------
 
@@ -123,16 +124,26 @@ if ($customImageEnabled == "Enabled") {
     // Plex Module Connect to Plex
     // $url = "http://$plexServer:32400/status/sessions?X-Plex-Token=$plexToken";
     $url = "$URLScheme://$plexServer:32400/status/sessions?X-Plex-Token=$plexToken";
+    pmp_Logging("getMediaURL", "Session URL: $url");
     // Store this for debugging
     $data['sessionUrl'] = $url;
     $data['plexClient'] = $plexClient;
     $data['plexClientName'] = $plexClientName;
     $getXml = file_get_contents($url);
+
     $xml = simplexml_load_string($getXml) or die("feed not loading");
     $isPlaying = false;
     if ($xml['size'] != '0') {
         $data['hasXml'] = true;
-        foreach ($xml->Video as $clients) {
+
+        if ($xml->Video) {
+            $mediaType = "Video";
+        }
+        if ($xml->Track) {
+            $mediaType = "Track";
+        }
+
+        foreach ($xml->$mediaType as $clients) {
             // If this matches our client IP or name, gather data
             if (strstr($clients->Player['address'], $plexClient) || strstr($clients->Player['title'], $plexClientName)) {
                 $isPlaying = true;
@@ -141,9 +152,7 @@ if ($customImageEnabled == "Enabled") {
                 $topSelection = $nowShowingTop;
                 $bottomSelection = $nowShowingBottom;
                 $data['hasClient1'] = true;
-                $mediaTitle = $clients['title'];
-                $mediaSummary = $clients['summary'];
-                $mediaTagline = $clients['tagline'];
+
                 $topSize = $nowShowingTopFontSize;
                 $topColor = $nowShowingTopFontColor;
                 $bottomSize = $nowShowingBottomFontSize;
@@ -156,21 +165,44 @@ if ($customImageEnabled == "Enabled") {
                 $bottomFontID = $nowShowingBottomFontID;
 
                 $mediaArt_Status = $nowShowingBackgroundArt;
-                //Now Showing Sections
-                if (strstr($clients['type'], "movie")) {
-                    $mediaThumb = $clients['thumb']; // Poster Art
-                    $mediaArt = $clients['art']; // Background Art
-                } elseif (strstr($clients['type'], "episode")) {
-                    if ($TVCoverArt_Play == "show") {
-                        $mediaThumb = $clients['grandparentThumb']; // Show Cover Art
-                    }
-                    elseif ($TVCoverArt_Play == "season") {
-                        $mediaThumb = $clients['parentThumb']; // Season Cover Art
-                    }
-                    else {
-                        $mediaThumb = $clients['grandparentThumb']; // Show Cover Art
-                    }
-                    $mediaArt = $clients['art']; // Background Art
+                $TVCoverArt_Play = $nowShowingShowTVThumb;
+
+                $mediaTitle = $clients['title']; // Default
+                $mediaTagline = $clients['tagline']; // Default
+                $mediaSummary = $clients['summary']; // Default
+                $mediaArt = $clients['art']; // Default
+                $mediaThumb = $clients['thumb']; // Default
+
+                // (strstr($clients['type'], "movie") // Notes for validation
+
+                switch ($clients['type']) {
+                    case "movie":
+                        plex_metadata_title("movie");
+                        plex_metadata_summary("movie");
+                        plex_metadata_tagline("movie");
+                        plex_metadata_art("movie");
+                        plex_metadata_thumb("movie");
+                        break;
+                    case "episode":
+                        plex_metadata_title($TVCoverArt_Play);
+                        plex_metadata_summary($TVCoverArt_Play);
+                        plex_metadata_tagline($TVCoverArt_Play);
+                        plex_metadata_art($TVCoverArt_Play);
+                        plex_metadata_thumb($TVCoverArt_Play);
+                        break;
+                    case "track":
+                        plex_metadata_title("track");
+                        plex_metadata_summary("track");
+                        plex_metadata_tagline("track");
+                        plex_metadata_art("track");
+                        plex_metadata_thumb("track");
+                        break;
+                    default:
+                        plex_metadata_title("movie");
+                        plex_metadata_summary("movie");
+                        plex_metadata_tagline("movie");
+                        plex_metadata_art("movie");
+                        plex_metadata_thumb("movie");
                 }
 
                 //Progress Bar
@@ -208,42 +240,49 @@ if ($customImageEnabled == "Enabled") {
         $mediaArt_Status = $comingSoonBackgroundArt;
 
         //Multi Movie Section Support
-        $plexServerMovieSections = explode(",", $plexServerMovieSection);
-        $useSection = rand(0, count($plexServerMovieSections) - 1);
-        // $MoviesURL = 'http://' . $plexServer . ':32400/library/sections/' . $plexServerMovieSections[$useSection] . '/' . $comingSoonShowSelection . '?X-Plex-Token=' . $plexToken . '';
-        $MoviesURL = $URLScheme . '://' . $plexServer . ':32400/library/sections/' . $plexServerMovieSections[$useSection] . '/' . $comingSoonShowSelection . '?X-Plex-Token=' . $plexToken . '';
-        $getMovies = file_get_contents($MoviesURL);
-        $xmlMedia = simplexml_load_string($getMovies) or die("feed not loading");
-        $countMovies = count($xmlMedia);
-        if ($countMovies > '0') {
+        plex_random_media(1); // Scan Libraries for Media
+
+        if ($viewGroup == "track") {
+            unset($plexServerMovieSections[$useSection]);
+            $plexServerMovieSection = implode(",", $plexServerMovieSections);
+            pmp_Logging("getMediaURL", "Library (Array - Updated): $plexServerMovieSection");
+
+            plex_random_media(2);
+        }
+
+        $countMedia = count($xmlMedia);
+        if ($countMedia > '0') {
             // Movies
             foreach ($xmlMedia->Video as $movie) {
                 $movies[] = strip_tags($movie['title']);
             }
             $random_keys = array_rand($movies, 1);
             $showMedia = $movies[$random_keys];
-            foreach ($xmlMedia->Video as $movie) {
-                if (strstr($movie['title'], $showMedia)) {
-                    $mediaThumb = $movie['thumb']; // Poster Art
-                    $mediaTitle = $movie['title'];
-                    $mediaSummary = $movie['summary'];
-                    $mediaTagline = $movie['tagline'];
-                    $mediaArt = $movie['art']; // Background Art
+
+            foreach ($xmlMedia->Video as $clients) {
+                if (strstr($clients['title'], $showMedia)) {
+                    plex_metadata_title("movie");
+                    plex_metadata_summary("movie");
+                    plex_metadata_tagline("movie");
+                    plex_metadata_art("movie");
+                    plex_metadata_thumb("movie");
                 }
             }
+
             // TV Shows
             foreach ($xmlMedia->Directory as $show) {
                 $shows[] = strip_tags($show['title']);
             }
             $random_keys = array_rand($shows, 1);
             $showMedia = $shows[$random_keys];
-            foreach ($xmlMedia->Directory as $show) {
-                if (strstr($show['title'], $showMedia)) {
-                    $mediaThumb = $show['thumb']; // Poster Art
-                    $mediaTitle = $show['title'];
-                    $mediaSummary = $show['summary'];
-                    $mediaTagline = $show['tagline']; // TV Shows do not contain tagline
-                    $mediaArt = $show['art']; // Background Art
+
+            foreach ($xmlMedia->Directory as $clients) {
+                if (strstr($clients['title'], $showMedia)) {
+                    plex_metadata_title($TVCoverArt_Play);
+                    plex_metadata_summary($TVCoverArt_Play);
+                    plex_metadata_tagline($TVCoverArt_Play);
+                    plex_metadata_art($TVCoverArt_Play);
+                    plex_metadata_thumb($TVCoverArt_Play);
                 }
             }
         }
@@ -255,40 +294,70 @@ if ($customImageEnabled == "Enabled") {
 if ($customImageEnabled != "Enabled") {
     // Check to see if we should cache our art
     if ($cacheEnabled) {
+        // Media Thumb (Poster) - Future: Move into function
         $mediaThumb_ID = explode("/", $mediaThumb);
         $mediaThumb_ID = trim($mediaThumb_ID[count($mediaThumb_ID) - 1], '/');
-        $filename = $cachePath . $mediaThumb_ID;
-        $mediaThumb_URL = "$URLScheme://$plexServer:32400$mediaThumb?X-Plex-Token=$plexToken";
-        // There's nothing else to do here, just save it
-        if (!file_exists($filename)) {
-            file_put_contents("$cachePath/$mediaThumb_ID", fopen("$mediaThumb_URL", 'r'));  // Not using getPoster function and using older un-secure function
+
+        if (!isset($mediaThumb_MetadataID) || trim($mediaThumb_MetadataID) === '') {
+            $mediaThumb_CacheFileName = $mediaThumb_ID;
+        } else {
+            $mediaThumb_CacheFileName = $mediaThumb_ID . "_" . $mediaThumb_MetadataID;
         }
-        $mediaThumb_Display = "url('$cachePath/$mediaThumb_ID')";
+        // $mediaThumb_CacheFullName = $cachePath . $mediaThumb_CacheFileName;
+        $mediaThumb_CacheFullName = join('/', array(trim($cachePath, '/'), trim($mediaThumb_CacheFileName, '/')));
+        pmp_Logging("getCacheFile", "Cache File @ Output (mediaThumb) - $mediaThumb_CacheFullName");
+
+        $mediaThumb_URL = "$URLScheme://$plexServer:32400$mediaThumb?X-Plex-Token=$plexToken";
         pmp_Logging("getMediaThumb", "$mediaThumb_ID ($cachePath) - $mediaThumb_URL");
 
+        // There's nothing else to do here, just save it
+        if (!file_exists($mediaThumb_CacheFullName)) {
+            file_put_contents("$mediaThumb_CacheFullName", fopen("$mediaThumb_URL", 'r'));
+        }
+
+        $mediaThumb_CacheURL = $mediaThumb_CacheFullName;
+
+        // $mediaThumb_Display = "url('$mediaThumb_CacheURL')"; // Unsecure URL
+        $mediaThumb_Display = "url('data:image/jpeg;base64,".getCachePoster($mediaThumb_CacheURL)."')"; // Secure URL
+        // pmp_Logging("getMediaThumb", "mediaThumb (Display - Secure) - $mediaThumb_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
+
+        // Media Art (Background) - Future: Move into function
         $mediaArt_ID = explode("/", $mediaArt);
         $mediaArt_ID = trim($mediaArt_ID[count($mediaArt_ID) - 1], '/');
-        $filename = $cacheArtPath . $mediaArt_ID;
-        $mediaArt_URL = "$URLScheme://$plexServer:32400$mediaArt?X-Plex-Token=$plexToken";
-        // There's nothing else to do here, just save it
-        if (!file_exists($filename)) {
-            file_put_contents("$cacheArtPath/$mediaArt_ID", fopen("$mediaArt_URL", 'r'));  // Not using getPoster function and using older un-secure function
-        }
-        $mediaArt_Display = "url('$cacheArtPath/$mediaArt_ID')";
-        pmp_Logging("getMediaArt", "$mediaArt_ID ($cacheArtPath) - $mediaArt_URL");
 
+        if (isset($mediaArt_ID) && trim($mediaArt_ID) != '') {
+            if (!isset($mediaArt_MetadataID) || trim($mediaArt_MetadataID) === '') {
+                $mediaArt_CacheFileName = $mediaArt_ID;
+            } else {
+                $mediaArt_CacheFileName = $mediaArt_ID . "_" . $mediaArt_MetadataID;
+            }
+            $mediaArt_CacheFullName = join('/', array(trim($cacheArtPath, '/'), trim($mediaArt_CacheFileName, '/')));
+            pmp_Logging("getCacheFile", "Cache File @ Output (mediaArt) - $mediaArt_CacheFullName");
+
+            $mediaArt_URL = "$URLScheme://$plexServer:32400$mediaArt?X-Plex-Token=$plexToken";
+            pmp_Logging("getMediaArt", "$mediaArt_ID ($cacheArtPath) - $mediaArt_URL");
+
+            // There's nothing else to do here, just save it
+            if (!file_exists($mediaArt_CacheFullName)) {
+                file_put_contents("$mediaArt_CacheFullName", fopen("$mediaArt_URL", 'r'));
+            }
+
+            $mediaArt_CacheURL = $mediaArt_CacheFullName;
+
+            // $mediaArt_Display = "url('$mediaArt_CacheURL')"; // Unsecure URL
+            $mediaArt_Display = "url('data:image/jpeg;base64,".getCachePoster($mediaArt_CacheURL)."')"; // Secure URL
+            // pmp_Logging("getMediaArt", "mediaArt (Display - Secure) - $mediaArt_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
+        }
     } else {
-        $mediaThumb_Display = "url('data:image/jpeg;base64,".getPoster($mediaThumb)."')";
-        // $mediaThumb_Display = "url('$URLScheme://$plexServer:32400$mediaThumb?X-Plex-Token=$plexToken')";
-        if (empty($mediaThumb_Display)) {
-            $mediaThumb_Display = "url('$URLScheme://$plexServer:32400$mediaThumb?X-Plex-Token=$plexToken')";
-        }
+        // $mediaThumb_Display = "url('$URLScheme://$plexServer:32400$mediaThumb?X-Plex-Token=$plexToken')"; // Unsecure URL
+        $mediaThumb_Display = "url('data:image/jpeg;base64,".getPoster($mediaThumb)."')"; // Secure URL
+        // pmp_Logging("getMediaThumb", "mediaThumb (Display - Secure) - $mediaThumb_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
 
-        $mediaArt_Display = "url('data:image/jpeg;base64,".getPoster($mediaArt)."')";
-        if (empty($mediaArt_Display)) {
-            $mediaArt_Display = "url('$URLScheme://$plexServer:32400$mediaArt?X-Plex-Token=$plexToken')";
-        }
+        // $mediaArt_Display = "url('$URLScheme://$plexServer:32400$mediaArt?X-Plex-Token=$plexToken')"; // Unsecure URL
+        $mediaArt_Display = "url('data:image/jpeg;base64,".getPoster($mediaArt)."')"; // Secure URL
+        // pmp_Logging("getMediaArt", "mediaArt (Display - Secure) - $mediaArt_Display"); // DO NOT LOG SECURE URL - DATA UNUSABLE AND LOGS BECOME UNREADABLE
     }
+
     // Figure out which text goes where
     switch($topSelection) {
         case 'title': $topText = $mediaTitle;break;

--- a/getPoster.php
+++ b/getPoster.php
@@ -17,13 +17,13 @@ function getPoster($artWorkLocation) {
 		$URLScheme = "http";
 	}
 
-	// $posterUrl = "http://$plexServer:32400$artWorkLocation?X-Plex-Token=$plexToken";
-	$posterUrl = "$URLScheme://$plexServer:32400$artWorkLocation?X-Plex-Token=$plexToken";
+	// $mediaUrl = "http://$plexServer:32400$artWorkLocation?X-Plex-Token=$plexToken";
+	$mediaUrl = "$URLScheme://$plexServer:32400$artWorkLocation?X-Plex-Token=$plexToken";
 
-	pmp_Logging("getPoster", "$posterUrl");
+	pmp_Logging("getPoster", "$mediaUrl");
 
 	// Grab Poster
-	$ch = curl_init($posterUrl);
+	$ch = curl_init($mediaUrl);
 	curl_setopt_array(
 		$ch,
 		 array(
@@ -47,4 +47,50 @@ function getPoster($artWorkLocation) {
 	// Return Base64
 	return $imgBase64;
 }
+
+function getCachePoster($cacheURL) {
+	global $plexServer, $plexToken, $plexServerSSL, $plexServerDirect;
+	$PMPServer = $_SERVER['HTTP_HOST'];
+
+	// Setting SSL Prefix
+	// if ($plexServerSSL) {
+		// $URLScheme = "https";
+		// $plexServer = "$plexServerDirect";
+	// }
+	// else {
+		$URLScheme = "http";
+	// }
+
+	// $mediaUrl = "http://$plexServer:32400$artWorkLocation?X-Plex-Token=$plexToken";
+	$mediaUrl = "$URLScheme://$PMPServer/$cacheURL";
+
+	pmp_Logging("getCachePoster", "$mediaUrl");
+
+	// Grab Poster
+	$ch = curl_init($mediaUrl);
+	curl_setopt_array(
+		$ch,
+		 array(
+			CURLOPT_RETURNTRANSFER  => true
+		)
+	);
+	$imgRaw = curl_exec($ch);
+	curl_close($ch);
+
+	// Get information about the image.
+	$imgInfo=getImageSizeFromString($imgRaw);
+
+	// Ensure image, is indeed an image.
+	if (empty($imgInfo['mime']) || strpos($imgInfo['mime'], 'image/') !== 0) {
+		die('Invalid Image');
+	}
+
+	// Create base64 version of image
+	$imgBase64 = base64_encode($imgRaw);
+
+	// Return Base64
+	return $imgBase64;
+}
+
+
 ?>

--- a/index.php
+++ b/index.php
@@ -11,7 +11,7 @@ $pmpImageSpeed = ($pmpImageSpeed * 1000);
 <html lang="en">
 <head>
     <?php HeaderInfo(basename(__FILE__)); ?>
-    
+
     <style>
         .comingSoonTop {
             font-size: <?php echo $comingSoonTopFontSize?>px;
@@ -34,10 +34,7 @@ $pmpImageSpeed = ($pmpImageSpeed * 1000);
                     if (key == "middle") {
                         $('#' + key).css('background-image', val);
                     } else if (key == "mediaArt") {
-                        $('body').css('background-image', val);
-                        $('body').css('background-repeat', 'no-repeat');
-                        $('body').css('background-attachment', 'fixed');
-                        $('body').css('background-size', 'cover');
+                        $('.' + key).css('background-image', val);
                     } else {
                         $('#' + key).html(val);
                     }
@@ -64,10 +61,7 @@ $pmpImageSpeed = ($pmpImageSpeed * 1000);
                         if (key == "middle") {
                             $('#' + key).css('background-image', val);
                         } else if (key == "mediaArt") {
-                            $('body').css('background-image', val);
-                            $('body').css('background-repeat', 'no-repeat');
-                            $('body').css('background-attachment', 'fixed');
-                            $('body').css('background-size', 'cover');
+                            $('.' + key).css('background-image', val);
                         } else {
                             $('#' + key).html(val);
                         }
@@ -80,28 +74,31 @@ $pmpImageSpeed = ($pmpImageSpeed * 1000);
 </head>
 
 <body>
-<div id="container">
-    <div id="alert" align="center" class="center"></div>
-    <div id="top" style="overflow: hidden;" align="center" class="center"></div>
-    <div id="middle" class="middle"></div>
-    <div id="bottom" style="overflow: hidden;" align="center" class="center"></div>
-</div>
-<div class="modal fade" id="myModal">
-    <div class="modal-dialog modal-lg">
-        <div class="modal-content bmd-modalContent">
+    <div class="mediaArt"></div>
 
-            <div class="modal-body">
+    <div id="container">
+        <div id="alert" align="center" class="center"></div>
+        <div id="top" style="overflow: hidden;" align="center" class="center"></div>
+        <div id="middle" class="middle"></div>
+        <div id="bottom" style="overflow: hidden;" align="center" class="center"></div>
+    </div>
 
-                <div class="close-button">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+    <div class="modal fade" id="myModal">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content bmd-modalContent">
+
+                <div class="modal-body">
+
+                    <div class="close-button">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    </div>
+                    <iframe class="embed-responsive-item" id='settingFrame' frameborder="0"></iframe>
+
                 </div>
-                <iframe class="embed-responsive-item" id='settingFrame' frameborder="0"></iframe>
 
-            </div>
-
-        </div><!-- /.modal-content -->
-    </div><!-- /.modal-dialog -->
-</div><!-- /.modal -->
+            </div><!-- /.modal-content -->
+        </div><!-- /.modal-dialog -->
+    </div><!-- /.modal -->
 </body>
 
 </html>

--- a/settings/PMPInfo.php
+++ b/settings/PMPInfo.php
@@ -1,6 +1,6 @@
 <?php
 
 // Release Information
-$version = '2.8.1';
+$version = "2.9.0";
 
 ?>

--- a/settings/nowShowing.php
+++ b/settings/nowShowing.php
@@ -64,6 +64,30 @@ GenerateCSS_Font_ALL();
                                         </p>
                                     </div>
 
+                                    <div class="form-group advanced-setting">
+                                        Show TV Show:&nbsp;
+
+                                        <select style="display: inline;"
+                                            id="nowShowingShowTVThumb" name="nowShowingShowTVThumb">
+                                            <option value="episode" <?php if ($nowShowingShowTVThumb == 'episode') {
+                                                echo "selected";
+                                            } ?>>Episode
+                                            </option>                                            
+                                            <option value="season" <?php if ($nowShowingShowTVThumb == 'season') {
+                                                echo "selected";
+                                            } ?>>Season
+                                            </option>
+                                            <option value="series" <?php if ($nowShowingShowTVThumb == 'series') {
+                                                echo "selected";
+                                            } ?>>Series
+                                            </option>
+                                        </select>
+
+                                        <!-- <p class="help-block">
+                                        </p> -->
+                                        <hr>
+                                    </div>
+
                                     <div class="form-group">
                                         <h3>Top Text Option:</h3>
                                         <div class="input-group">

--- a/settings/nowShowing.php
+++ b/settings/nowShowing.php
@@ -62,17 +62,18 @@ GenerateCSS_Font_ALL();
                                         <p class="help-block">
                                             Set background art to match background of Plex media.
                                         </p>
+                                        <hr>
                                     </div>
 
                                     <div class="form-group advanced-setting">
-                                        Show TV Show:&nbsp;
+                                        Display TV Show:&nbsp;
 
                                         <select style="display: inline;"
                                             id="nowShowingShowTVThumb" name="nowShowingShowTVThumb">
                                             <option value="episode" <?php if ($nowShowingShowTVThumb == 'episode') {
                                                 echo "selected";
                                             } ?>>Episode
-                                            </option>                                            
+                                            </option>
                                             <option value="season" <?php if ($nowShowingShowTVThumb == 'season') {
                                                 echo "selected";
                                             } ?>>Season
@@ -83,8 +84,9 @@ GenerateCSS_Font_ALL();
                                             </option>
                                         </select>
 
-                                        <!-- <p class="help-block">
-                                        </p> -->
+                                        <p class="help-block">
+                                            Display the poster, background art and information for TV Shows in your library.
+                                        </p>
                                         <hr>
                                     </div>
 


### PR DESCRIPTION
v2.9.0 Community Updates
Updates – TV Show Integration (Issue #23):
- Add new variables: $nowShowingShowTVThumb (Default: series)
- Add new dropdown in 'Now Showing' (Episode/Series/Season) to set Thumb (Poster)
- Add new variables: $comingSoonShowTVThumb (Default: series)

Updates - Music Integration (Issue #30):
- Add check to see if playing video is 'video' or 'track'
- Add metadata check for 'track'

Updates and Bug Fixes:
- Create UpdateVersion.py to update all the versions in a single update.
- Update the url for cache images to use the 'encrypted’ url like the non-cached version (Issue #25)
- Add Blur to mediaArt (Background) (Issue #27)
- Fix issue with background art and poster do not match (Issue #27)
- Move some actions out of the getData.php to its own PlexLib.php file to split into functions for better organization and scale.
- Update 'Coming Soon' metadata reader to use PlexLib functions so to share same business logic.

ToDos:
- Add switches to Enable/Disable TV Shows within the 'Coming Soon' and/or 'Now Playing' (Issue #23)
- Add switches to Enable/Disable Music within the 'Coming Soon' and/or 'Now Playing' (Issue #30)
    - 'Coming Soon' for music does not work when using 'unwatched'; currently music is skipped in this mode.
- Add switches to Enable/Disable Thumb (Poster) within the 'Coming Soon' and/or 'Now Playing' - If you only want 'art' only
    - This will also require a small rework to how the blur function works.
- Add Music metadata to 'Coming Soon' rotation - Currently shows as blank data
